### PR TITLE
Use is_callable() instead of function_exists().

### DIFF
--- a/class.phpmailer-bmh.php
+++ b/class.phpmailer-bmh.php
@@ -303,7 +303,7 @@ class BounceMailHandler {
    * @return boolean
    */
   function processMailbox($max=false) {
-    if ( empty($this->action_function) || !function_exists($this->action_function) ) {
+    if ( empty($this->action_function) || !is_callable($this->action_function) ) {
       $this->error_msg = 'Action function not found!';
       $this->output();
       return false;


### PR DESCRIPTION
Allows for 'SomeClass::someMethod', array('SomeClass', 'someMethod'), or array($someObject, 'someMethod')
