### PR TITLE
Add full headers and body to params returned to the callback function 

### DIFF
--- a/class.phpmailer-bmh.php
+++ b/class.phpmailer-bmh.php
@@ -464,6 +464,8 @@ class BounceMailHandler {
     $header      = imap_header($this->_mailbox_link,$pos);
     $subject     = strip_tags($header->subject);
     $body        = '';
+    $header_full = imap_fetchheader($this->_mailbox_link,$pos);
+    $body_full   = imap_body($this->_mailbox_link,$pos);
 
     if ($type == 'DSN') {
       // first part of DSN (Delivery Status Notification), human-readable explanation
@@ -536,14 +538,14 @@ class BounceMailHandler {
       if ( trim($email) == '' ) {
         $email = $header->fromaddress;
       }
-      $params = array($pos,$bounce_type,$email,$subject,$xheader,$remove,$rule_no,$rule_cat,$totalFetched,$body);
+      $params = array($pos,$bounce_type,$email,$subject,$xheader,$remove,$rule_no,$rule_cat,$totalFetched,$body,$header_full,$body_full);
       call_user_func_array($this->action_function,$params);
     } else { // match rule, do bounce action
       if ($this->testmode) {
         $this->output('Match: ' . $rule_no . ':' . $rule_cat . '; ' . $bounce_type . '; ' . $email);
         return true;
       } else {
-        $params = array($pos,$bounce_type,$email,$subject,$xheader,$remove,$rule_no,$rule_cat,$totalFetched,$body);
+        $params = array($pos,$bounce_type,$email,$subject,$xheader,$remove,$rule_no,$rule_cat,$totalFetched,$body,$header_full,$body_full);
         return call_user_func_array($this->action_function,$params);
       }
     }


### PR DESCRIPTION
Add full headers and body to params returned to the callback function so that a tracking id can picked up from the original email
